### PR TITLE
Added compute_metrics() to train.py

### DIFF
--- a/tone/train.py
+++ b/tone/train.py
@@ -1,6 +1,8 @@
 from functools import partial
 
 import torch
+import evaluate
+import numpy as np
 from datasets import Audio, load_dataset
 from transformers import (
     EarlyStoppingCallback,
@@ -47,6 +49,17 @@ def collate_fn_train(batch, feature_extractor):
         "attention_mask": features["attention_mask"],
         "labels": labels,
     }
+
+metric = evaluate.load("mse")
+
+def compute_metrics(eval_pred):
+    predictions, labels = eval_pred
+
+    predictions = np.asarray(predictions, dtype=np.float32)
+    labels = np.asarray(labels, dtype=np.float32)
+
+    mse = np.mean((predictions - labels) ** 2)
+    return {"mse": mse}
 
 
 if __name__ == "__main__":
@@ -98,6 +111,7 @@ if __name__ == "__main__":
             )
         ],
         eval_dataset=dataset["validation"],
+        compute_metrics=compute_metrics,
     )
 
     trainer.train()


### PR DESCRIPTION
Added def compute_metrics() which returns 'eval_loss', 'eval_mse', 'eval_runtime', 'eval_samples_per_second', 'eval_steps_per_second', and 'epoch'

One issue, have to run "pip install datasets transformers torch evaluate nltk rouge_score" in order to run code. I don't know which part of this is required and which part is unneccessary(If I were guessing, I would say that you can remove nltk and roughe_score as I believe those are in the huggingface command to train classification AI and not regression AI).